### PR TITLE
Fix pictrs environent variable for setting API_KEY

### DIFF
--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     # entrypoint: /sbin/tini -- /usr/local/bin/pict-rs -p /mnt -m 4 --image-format webp
     environment:
       - PICTRS_OPENTELEMETRY_URL=http://otel:4137
-      - PICTRS__API_KEY={{ postgres_password }}
+      - PICTRS__SERVER__API_KEY={{ postgres_password }}
       - RUST_LOG=debug
       - RUST_BACKTRACE=full
       - PICTRS__MEDIA__VIDEO_CODEC=vp9


### PR DESCRIPTION
Environment variable for setting API Key has changed in v0.4.0. This fixes the error: Invalid API Key with the old variable.